### PR TITLE
docs: fix link in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ If you want to print the case yourself, you can also get just the electronics Ki
 # Build guide
 
 Please find detailed build instructions here:
-https://docs.bastardkb.com/hc/en-us/articles/360020031340-Kit-contents-and-required-tools
+https://docs.bastardkb.com/hc/en-us/articles/4415744748306-Kit-contents-and-required-tools
 
 # Finding help
 


### PR DESCRIPTION
The link to the build guide leads to a login screen. However, there's a
publicly available build guide on the website. This commit replaces the
old link with the publicly available one.