### PR TITLE
Fix charybdis repo url in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ The STL files are included in this Github repository.
 
 Please find detailed instructions on how to print the case on the online instructions linked below.
 
-There are optional tents, use the same ones as for the [Charybdis Mini 3x6](github.com/bastardkb/charybdis).
+There are optional tents, use the same ones as for the [Charybdis Mini 3x6](https://github.com/bastardkb/charybdis).
 
 
 ## Get a kit from BastardKB


### PR DESCRIPTION
Fixes:

![CleanShot 2024-07-07 at 01 28 09](https://github.com/Bastardkb/TBK-Mini/assets/13662664/ca0f9715-61bd-43cd-87d0-287d17ad4465)
